### PR TITLE
Fix HLS Bug and assertions on wl, also adjust instr encoding

### DIFF
--- a/src/main/resources/cpp/lib/BISMOInstruction.cpp
+++ b/src/main/resources/cpp/lib/BISMOInstruction.cpp
@@ -51,7 +51,7 @@ std::ostream& operator<<(std::ostream& os, const BISMOFetchRunInstruction& r)
   os << "tiles_per_row: " << r.tiles_per_row << std::endl;
   os << "dram_base: " << (uint64_t) r.dram_base << std::endl;
   os << "dram_block_offset_bytes: " << r.dram_block_offset_bytes << std::endl;
-  os << "dram_block_size_bytes: " << r.dram_block_size_bytes << std::endl;
+  os << "dram_block_size_qword: " << r.dram_block_size_qword << std::endl;
   os << "dram_block_count: " << r.dram_block_count << std::endl;
   os << "========================================" << std::endl;
   return os;

--- a/src/main/resources/cpp/lib/BISMOInstruction.hpp
+++ b/src/main/resources/cpp/lib/BISMOInstruction.hpp
@@ -105,7 +105,7 @@ struct BISMOFetchRunInstruction {
   ap_uint<1> bram_id_range;
   ap_uint<16> bram_addr_base;
   ap_uint<32> dram_base;
-  ap_uint<16> dram_block_size_bytes;
+  ap_uint<16> dram_block_size_qword;
   ap_uint<24> dram_block_offset_bytes;
   ap_uint<8> dram_block_count;
   ap_uint<16> tiles_per_row;
@@ -119,7 +119,7 @@ struct BISMOFetchRunInstruction {
     ret(15, 15) = bram_id_range;
     ret(31, 16) = bram_addr_base;
     ret(63, 32) = dram_base;
-    ret(79, 64) = dram_block_size_bytes;
+    ret(79, 64) = dram_block_size_qword;
     ret(103, 80) = dram_block_offset_bytes;
     ret(111, 104) = dram_block_count;
     ret(127, 112) = tiles_per_row;
@@ -134,7 +134,7 @@ struct BISMOFetchRunInstruction {
     bram_id_range = ret(15, 15);
     bram_addr_base = ret(31, 16);
     dram_base = ret(63, 32);
-    dram_block_size_bytes = ret(79, 64);
+    dram_block_size_qword = ret(79, 64);
     dram_block_offset_bytes = ret(103, 80);
     dram_block_count = ret(111, 104);
     tiles_per_row = ret(127, 112);
@@ -148,7 +148,7 @@ struct BISMOFetchRunInstruction {
     bram_id_range = 0;
     bram_addr_base = 0;
     dram_base = 0;
-    dram_block_size_bytes = 0;
+    dram_block_size_qword = 0;
     dram_block_offset_bytes = 0;
     dram_block_count = 0;
     tiles_per_row = 0;

--- a/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
+++ b/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
@@ -53,7 +53,7 @@
 #define N_STAGES                  3
 #define FETCH_ADDRALIGN           8
 #define FETCH_SIZEALIGN           8
-#define FETCH_BLOCK_MAX           (1 << (BISMO_LIMIT_DRAM_BSIZE_BITS-1))
+#define FETCH_BLOCK_MAX           ((1 << BISMO_LIMIT_DRAM_BSIZE_BITS)-1)
 
 #define max_local(x,y)                  (x > y ? x : y)
 #define FETCH_ALIGN               max_local(FETCH_ADDRALIGN, FETCH_SIZEALIGN)

--- a/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
+++ b/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
@@ -252,18 +252,18 @@ public:
       ASSERT_BITS(f.bram_id_range, 1);
       ASSERT_BITS(f.bram_addr_base, BISMO_LIMIT_INBUFADDR_BITS);
       ASSERT_BITS(f.dram_base, BISMO_LIMIT_DRAMADDR_BITS);
-      ASSERT_BITS(f.dram_block_size_bytes, BISMO_LIMIT_DRAM_BSIZE_BITS);
+      ASSERT_BITS(f.dram_block_size_qword, BISMO_LIMIT_DRAM_BSIZE_BITS);
       ASSERT_BITS(f.dram_block_offset_bytes, BISMO_LIMIT_DRAM_BOFF_BITS);
       ASSERT_BITS(f.dram_block_count, BISMO_LIMIT_DRAM_BCNT_BITS);
       ASSERT_BITS(f.tiles_per_row, BISMO_LIMIT_INBUFADDR_BITS);
       // catch 0-sized transfers, may be due to overflow
-      assert(f.dram_block_size_bytes != 0);
+      assert(f.dram_block_size_qword != 0);
 
       const size_t exec_to_fetch_width_ratio = m_cfg.dpaDimCommon / m_cfg.readChanWidth;
       // ensure all DRAM accesses are aligned
       assert(((uint64_t) f.dram_base) % FETCH_ADDRALIGN == 0);
       assert(f.dram_block_offset_bytes % FETCH_ADDRALIGN == 0);
-      assert(f.dram_block_size_bytes % FETCH_SIZEALIGN == 0);
+      assert(f.dram_block_size_qword % FETCH_SIZEALIGN == 0);
       // ensure that BRAM accesses are within existing range
       assert(f.bram_id_start < get_num_fetch_nodes());
       //assert(f.bram_id_start + f.bram_id_range < get_num_fetch_nodes());

--- a/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
+++ b/src/main/resources/cpp/lib/BitSerialMatMulAccelDriver.hpp
@@ -53,7 +53,7 @@
 #define N_STAGES                  3
 #define FETCH_ADDRALIGN           8
 #define FETCH_SIZEALIGN           8
-#define FETCH_BLOCK_MAX           ((1 << BISMO_LIMIT_DRAM_BSIZE_BITS)-1)
+#define FETCH_BLOCK_MAX           ((1 << BISMO_LIMIT_DRAM_BSIZE_BITS + 3)-1)
 
 #define max_local(x,y)                  (x > y ? x : y)
 #define FETCH_ALIGN               max_local(FETCH_ADDRALIGN, FETCH_SIZEALIGN)

--- a/src/main/resources/cpp/lib/bismo_rt_matmul.cpp
+++ b/src/main/resources/cpp/lib/bismo_rt_matmul.cpp
@@ -63,12 +63,14 @@ MatrixMultiply::MatrixMultiply(
   // must have room for at least one stripe per bit position, as this is the
   // granularity we at which we do RHS tiling
   const bool rhs_tile_fits_in_ocm = (acc->get_rhs_total_BRAM_bytes()) >= FETCHEXEC_TOKENS*rhs_stripe_nbytes;
-  const bool rhs_tile_is_one_fetchblock = (rhs_stripe_nbytes <= FETCH_BLOCK_MAX);
+  // must be able to encode a fetchblock in the space defined by a fetch instruction
+  // there is a separate fetchblock for every bit-position
+  const bool rhs_tile_is_one_fetchblock = (rhs_stripe_nbytes / m_rhs->bits())<= FETCH_BLOCK_MAX;
   if(!rhs_tile_is_one_fetchblock || !rhs_tile_fits_in_ocm) {
     throw "RHS is too large and not currently supported in runtime library.";
   }
   const bool lhs_tile_fits_in_ocm = (acc->get_lhs_total_BRAM_bytes()) >= FETCHEXEC_TOKENS*lhs_stripe_nbytes;
-  const bool lhs_tile_is_one_fetchblock = lhs_stripe_nbytes <= FETCH_BLOCK_MAX;
+  const bool lhs_tile_is_one_fetchblock = (lhs_stripe_nbytes / m_lhs->bits()) <= FETCH_BLOCK_MAX;
   if(!lhs_tile_is_one_fetchblock || !lhs_tile_fits_in_ocm) {
     throw "LHS is too large and not currently supported in runtime library.";
   }

--- a/src/main/resources/cpp/lib/bismo_rt_matmul.cpp
+++ b/src/main/resources/cpp/lib/bismo_rt_matmul.cpp
@@ -60,20 +60,29 @@ MatrixMultiply::MatrixMultiply(
   const size_t tiles_n = m_rhs->outer_a() / cfg.dpaDimRHS;
   const size_t lhs_stripe_nbytes = m_lhs->bitserial_nbytes() / tiles_m;
   const size_t rhs_stripe_nbytes = m_rhs->bitserial_nbytes() / tiles_n;
+
   // must have room for at least one stripe per bit position, as this is the
-  // granularity we at which we do RHS tiling
+  // granularity at which we do RHS tiling
   const bool rhs_tile_fits_in_ocm = (acc->get_rhs_total_BRAM_bytes()) >= FETCHEXEC_TOKENS*rhs_stripe_nbytes;
   // must be able to encode a fetchblock in the space defined by a fetch instruction
   // there is a separate fetchblock for every bit-position
   const bool rhs_tile_is_one_fetchblock = (rhs_stripe_nbytes / m_rhs->bits())<= FETCH_BLOCK_MAX;
-  if(!rhs_tile_is_one_fetchblock || !rhs_tile_fits_in_ocm) {
-    throw "RHS is too large and not currently supported in runtime library.";
+  if(!rhs_tile_fits_in_ocm) {
+    throw "RHS is too large and not currently supported in runtime library. \n\nA single RHS stripe (D_n * K * lhs-bits) does not fit into On-Chip-Memory";
   }
+  if(!rhs_tile_is_one_fetchblock) {
+    throw "RHS is too large and not currently supported in runtime library. \n\nA single fetchblock in bytes (D_n * K / 8) is to large to be encoded internaly";
+  }
+
   const bool lhs_tile_fits_in_ocm = (acc->get_lhs_total_BRAM_bytes()) >= FETCHEXEC_TOKENS*lhs_stripe_nbytes;
   const bool lhs_tile_is_one_fetchblock = (lhs_stripe_nbytes / m_lhs->bits()) <= FETCH_BLOCK_MAX;
-  if(!lhs_tile_is_one_fetchblock || !lhs_tile_fits_in_ocm) {
-    throw "LHS is too large and not currently supported in runtime library.";
+  if(!lhs_tile_fits_in_ocm) {
+    throw "LHS is too large and not currently supported in runtime library. \n\nA single LHS stripe (D_m * K * lhs-bits) does not fit into On-Chip-Memory";
   }
+  if(!lhs_tile_is_one_fetchblock) {
+    throw "LHS is too large and not currently supported in runtime library. \n\nA single fetchblock in bytes (D_m * K / 8) is to large to be encoded internaly";
+  }
+  
   // create and fill in the descriptor
   m_igen_dsc.tiles_m = tiles_m;
   m_igen_dsc.tiles_k = tiles_k;

--- a/src/main/resources/hls/FetchInstrGen.cpp
+++ b/src/main/resources/hls/FetchInstrGen.cpp
@@ -52,7 +52,8 @@ void FetchInstrGen_RHSLHSTiling_Templated(
   #pragma HLS INTERFACE axis port=in
 
   BISMOFetchRunInstruction fetch;
-  BISMOSyncInstruction sync;
+  BISMOSyncInstruction sync_rec;
+  BISMOSyncInstruction sync_send;
 
   // set the invariants (values do not depend on loop iter)
   sync_rec.targetStage = stgFetch;

--- a/src/main/resources/hls/FetchInstrGen.cpp
+++ b/src/main/resources/hls/FetchInstrGen.cpp
@@ -141,7 +141,8 @@ void FetchInstrGen_RHSLHSTiling_Templated(
     // each bit position is one block
     fetch.dram_block_count = ins_in.bits_l;
     // each block is a group of Dm rows' worth of bits
-    fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_lhs_tile;
+    // this variable is right-shiftet by three to encode it as an octet
+    fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_lhs_tile >> 3;
     // block stride/skip is one bit position worth of bits
     fetch.dram_block_offset_bytes = ins_in.tiles_m * ins_in.tiles_k * bytes_per_lhs_tile;
     // IMPORTANT TODO: put in SW assertions around sizes of these, especially

--- a/src/main/resources/hls/FetchInstrGen.cpp
+++ b/src/main/resources/hls/FetchInstrGen.cpp
@@ -99,7 +99,9 @@ void FetchInstrGen_RHSLHSTiling_Templated(
       // each bit position is one block
       fetch.dram_block_count = ins_in.bits_r;
       // each block is a group of Dn rows' worth of bits
-      fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_rhs_tile;
+      // to save space and since the smallest unit of data handled by any part of the hardware is a octet (8 bytes)
+      // this variable is right-shiftet by three to encode it as an octet
+      fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_rhs_tile >> 3;
       // block stride/skip is one bit position worth of bits
       fetch.dram_block_offset_bytes = ins_in.tiles_n * ins_in.tiles_k * bytes_per_rhs_tile;
       // IMPORTANT TODO: put in SW assertions around sizes of these, especially

--- a/src/main/resources/hls/FetchInstrGen.cpp
+++ b/src/main/resources/hls/FetchInstrGen.cpp
@@ -99,9 +99,9 @@ void FetchInstrGen_RHSLHSTiling_Templated(
       // each bit position is one block
       fetch.dram_block_count = ins_in.bits_r;
       // each block is a group of Dn rows' worth of bits
-      // to save space and since the smallest unit of data handled by any part of the hardware is a octet (8 bytes)
-      // this variable is right-shiftet by three to encode it as an octet
-      fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_rhs_tile >> 3;
+      // to save space and since the smallest unit of data handled by any part of the hardware is a qword (8 bytes)
+      // this variable is right-shiftet by three to encode it as a qword
+      fetch.dram_block_size_qword = ins_in.tiles_k * bytes_per_rhs_tile >> 3;
       // block stride/skip is one bit position worth of bits
       fetch.dram_block_offset_bytes = ins_in.tiles_n * ins_in.tiles_k * bytes_per_rhs_tile;
       // IMPORTANT TODO: put in SW assertions around sizes of these, especially
@@ -141,8 +141,8 @@ void FetchInstrGen_RHSLHSTiling_Templated(
     // each bit position is one block
     fetch.dram_block_count = ins_in.bits_l;
     // each block is a group of Dm rows' worth of bits
-    // this variable is right-shiftet by three to encode it as an octet
-    fetch.dram_block_size_bytes = ins_in.tiles_k * bytes_per_lhs_tile >> 3;
+    // this variable is right-shiftet by three to encode it as a qword
+    fetch.dram_block_size_qword = ins_in.tiles_k * bytes_per_lhs_tile >> 3;
     // block stride/skip is one bit position worth of bits
     fetch.dram_block_offset_bytes = ins_in.tiles_m * ins_in.tiles_k * bytes_per_lhs_tile;
     // IMPORTANT TODO: put in SW assertions around sizes of these, especially

--- a/src/main/scala/FetchStage.scala
+++ b/src/main/scala/FetchStage.scala
@@ -297,7 +297,8 @@ class FetchDecoupledStage(val myP: FetchStageParams) extends Module {
   val bytesToBurstsRightShift = log2Up(bytesPerBurst)
   reader.block_intra_step := UInt(bytesPerBurst)
   // #beats for each block
-  reader.block_intra_count := current_runcfg.dram_block_size_bytes >> bytesToBurstsRightShift
+  // this is right shifted by three since dram_block_size_bytes is actually encoded in octets (8 Bytes)
+  reader.block_intra_count := (current_runcfg.dram_block_size_bytes >> bytesToBurstsRightShift) << 3
 
   // supply read requests to DRAM from BlockStridedRqGen
   reader.out <> io.dram.rd_req

--- a/src/main/scala/FetchStage.scala
+++ b/src/main/scala/FetchStage.scala
@@ -298,7 +298,7 @@ class FetchDecoupledStage(val myP: FetchStageParams) extends Module {
   reader.block_intra_step := UInt(bytesPerBurst)
   // #beats for each block
   // this is right shifted by three since dram_block_size_bytes is actually encoded in octets (8 Bytes)
-  reader.block_intra_count := (current_runcfg.dram_block_size_bytes >> bytesToBurstsRightShift) << 3
+  reader.block_intra_count := (current_runcfg.dram_block_size_bytes  << 3) >> bytesToBurstsRightShift
 
   // supply read requests to DRAM from BlockStridedRqGen
   reader.out <> io.dram.rd_req

--- a/src/main/scala/FetchStage.scala
+++ b/src/main/scala/FetchStage.scala
@@ -365,7 +365,8 @@ class FetchDecoupledStage(val myP: FetchStageParams) extends Module {
         regBlockBytesReceived := UInt(0)
         regBlocksReceived := UInt(0)
         regWaitInterconnect := UInt(0)
-        regBlockBytesAlmostFinished := io.stage_run.bits.dram_block_size_bytes - UInt(bytesPerBeat)
+        // this is right shifted by three since dram_block_size_bytes is actually encoded in octets (8 Bytes)
+        regBlockBytesAlmostFinished := (io.stage_run.bits.dram_block_size_bytes << 3)- UInt(bytesPerBeat)
       }
     }
     is(sGenReq) {


### PR DESCRIPTION
The commits up to a0a5ce6a... are firstly a fix of the io_sections in the FetchInstrGen to avoid the warning "Protocol 'io_section' contains conflicting I/O accesses" when synthesizing HLS. 
And secondly there is a fix for the assertion on the size of the fetch-instruction section called "dram_block_size_bytes". 

The other commits add more verbose assertion messages and change the encoding of dram_block_size_bytes from bytes to octets to enable bigger workloads.